### PR TITLE
ci: filterの前にcheckoutするように

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       go: ${{ steps.filter.outputs.go }}
       force: ${{ steps.filter.outputs.force }}
     steps:
+      - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
         id: filter
         with:


### PR DESCRIPTION
log:
```log
2025-07-11T18:28:09.2427199Z Current runner version: '2.326.0'
2025-07-11T18:28:09.2460482Z ##[group]Runner Image Provisioner
2025-07-11T18:28:09.2461958Z Hosted Compute Agent
2025-07-11T18:28:09.2462882Z Version: 20250710.361
2025-07-11T18:28:09.2463891Z Commit: 1aa91963755b73deaa955e512f5de173acfde7a8
2025-07-11T18:28:09.2465368Z Build Date: 2025-07-10T18:39:53Z
2025-07-11T18:28:09.2466403Z ##[endgroup]
2025-07-11T18:28:09.2467281Z ##[group]Operating System
2025-07-11T18:28:09.2468472Z Ubuntu
2025-07-11T18:28:09.2469223Z 24.04.2
2025-07-11T18:28:09.2470010Z LTS
2025-07-11T18:28:09.2470922Z ##[endgroup]
2025-07-11T18:28:09.2471813Z ##[group]Runner Image
2025-07-11T18:28:09.2472832Z Image: ubuntu-24.04
2025-07-11T18:28:09.2473867Z Version: 20250629.1.0
2025-07-11T18:28:09.2475825Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20250629.1/images/ubuntu/Ubuntu2404-Readme.md
2025-07-11T18:28:09.2478578Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20250629.1
2025-07-11T18:28:09.2480262Z ##[endgroup]
2025-07-11T18:28:09.2482065Z ##[group]GITHUB_TOKEN Permissions
2025-07-11T18:28:09.2485320Z Metadata: read
2025-07-11T18:28:09.2486299Z PullRequests: read
2025-07-11T18:28:09.2487312Z ##[endgroup]
2025-07-11T18:28:09.2490776Z Secret source: Actions
2025-07-11T18:28:09.2492187Z Prepare workflow directory
2025-07-11T18:28:09.2960397Z Prepare all required actions
2025-07-11T18:28:09.3016580Z Getting action download info
2025-07-11T18:28:09.5402194Z Download action repository 'dorny/paths-filter@v3' (SHA:de90cc6fb38fc0963ad72b210f1f284cd68cea36)
2025-07-11T18:28:09.8537983Z Complete job name: changes
2025-07-11T18:28:09.9276865Z ##[group]Run dorny/paths-filter@v3
2025-07-11T18:28:09.9277701Z with:
2025-07-11T18:28:09.9278653Z   filters: go:
  - '**/*.go'
  - '**/go.mod'
  - '**/go.sum'
  - '**/go.work'
  - '**/go.work.sum'
  - '**/testdata/**'
force:
  - '.github/workflows/**'
  - '.github/actions/**'
  - 'Makefile'
  - 'mise.toml'

2025-07-11T18:28:09.9279881Z   token: ***
2025-07-11T18:28:09.9280285Z   list-files: none
2025-07-11T18:28:09.9280670Z   initial-fetch-depth: 100
2025-07-11T18:28:09.9281290Z ##[endgroup]
2025-07-11T18:28:10.0295506Z ##[group]Get current git ref
2025-07-11T18:28:10.0310464Z [command]/usr/bin/git branch --show-current
2025-07-11T18:28:10.0374514Z fatal: not a git repository (or any of the parent directories): .git
2025-07-11T18:28:10.0398445Z ##[endgroup]
2025-07-11T18:28:10.0415947Z ##[error]The process '/usr/bin/git' failed with exit code 128
2025-07-11T18:28:10.0545548Z Evaluate and set job outputs
```
